### PR TITLE
fix: record_with_files_factory

### DIFF
--- a/pytest_oarepo/records.py
+++ b/pytest_oarepo/records.py
@@ -125,8 +125,6 @@ def record_with_files_factory(
             system_identity,
             draft["id"],
             expand=expand,
-            file_name=file_name,
-            custom_file_metadata=custom_file_metadata,
         )
         return record.to_dict()
 


### PR DESCRIPTION
These attributes aren't defined on RDMRecordService.publish() 